### PR TITLE
Add Blanao repo to repositories.py

### DIFF
--- a/repositories.py
+++ b/repositories.py
@@ -57,6 +57,6 @@ GROUP_REPOS = [
     [
         "group l",
         "Blanao",
-        ["https://github.com/<L>/<B>", "https://github.com/<L>/<C>", "etc."],
+        ["https://github.com/alexander34ro/DevOps"],
     ],
 ]


### PR DESCRIPTION
You can find the repository for group l (Blanao) at https://github.com/alexander34ro/DevOps