### PR TITLE
Allows running exercise from every directory

### DIFF
--- a/sessions/session_02/inspect_git_object1.py
+++ b/sessions/session_02/inspect_git_object1.py
@@ -3,9 +3,6 @@ import zlib
 
 
 fname = os.path.join(
-    os.environ["HOME"],
-    "Desktop",
-    "flask-minitwit-mongodb",
     ".git",
     "objects",
     "ec",

--- a/sessions/session_02/inspect_git_object2.py
+++ b/sessions/session_02/inspect_git_object2.py
@@ -3,9 +3,6 @@ import zlib
 
 
 fname = os.path.join(
-    os.environ["HOME"],
-    "Desktop",
-    "flask-minitwit-mongodb",
     ".git",
     "objects",
     "1e",

--- a/sessions/session_02/inspect_git_object3.py
+++ b/sessions/session_02/inspect_git_object3.py
@@ -3,9 +3,6 @@ import zlib
 
 
 fname = os.path.join(
-    os.environ["HOME"],
-    "Desktop",
-    "flask-minitwit-mongodb",
     ".git",
     "objects",
     "ee",


### PR DESCRIPTION
Exercise `session_02/Task03.md` relied on the repository being cloned to the desktop directory of the current user.
This PR changes the python scripts to use a relative path. This means that they can be used no matter where the repo is cloned (and even for other repositories too).